### PR TITLE
#2 Actually hide the quick result when blur the search field

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -87,6 +87,7 @@ header.main-header h1 {
 .search .search-quick-view.hidden {
     opacity: 0;
     transition: opacity 0s linear;
+    visibility: hidden;
 }
 
 .search .search-quick-view {


### PR DESCRIPTION
I put the property `visibility: hidden` to actually hide the result and avoid the click.